### PR TITLE
add base heroku api url to heroku-url.js

### DIFF
--- a/lib/foods.js
+++ b/lib/foods.js
@@ -1,0 +1,4 @@
+// This is the base url, last character is a "/" so don't include as first character
+// of specific herokuUrl api request enpoint
+// make requests with `herokuUrl + "api/v1/foods"` etc
+const herokuUrl = require("./heroku-url").herokuUrl

--- a/lib/heroku-url.js
+++ b/lib/heroku-url.js
@@ -1,0 +1,7 @@
+function herokuUrl() {
+  return "https://arcane-depths-57821.herokuapp.com/";
+};
+
+module.exports = {
+  herokuUrl: herokuUrl
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,3 @@
+// This is the base url
+// make requests with `herokuUrl + "api/v1/foods"` etc
+const herokuUrl = require("./heroku-url").herokuUrl

--- a/lib/meals.js
+++ b/lib/meals.js
@@ -1,0 +1,4 @@
+// This is the base url, last character is a "/" so don't include as first character
+// of specific herokuUrl api request enpoint
+// make requests with `herokuUrl + "api/v1/foods"` etc
+const herokuUrl = require("./heroku-url").herokuUrl


### PR DESCRIPTION
Created the function `herokuUrl()` in `lib/heroku-url.js` that returns `https://arcane-depths-57821.herokuapp.com/`. This way, we can require the file and store the function to a constant variable in files we will be making requests in. See either `lib/foods.js` or `lib/meals.js` for example documentation of requiring and storing to a variable.

To make a request, just call the const var + your desired endpoint, see below for example.
```javascript
$.ajax({
  type: "GET",
  url: herokuUrl + "api/v1/foods"
})
// http://turing-quantified-self-api.herokuapp.com/api/v1/foods
```

Let me know what you think! @bretfunk 😄 